### PR TITLE
refactor: simplify locale switching logic

### DIFF
--- a/resources/application/i18n.ts
+++ b/resources/application/i18n.ts
@@ -1,4 +1,3 @@
-import { WritableComputedRef } from "vue"
 import { createI18n } from "vue-i18n"
 import messages from "../i18n/locales.json"
 
@@ -9,10 +8,8 @@ declare module "vue-i18n" {
   export interface DefineLocaleMessage extends MessageSchema {}
 }
 
-export const i18n = createI18n<[MessageSchema], keyof typeof messages>({
+export const i18n = createI18n<[MessageSchema], keyof typeof messages, false>({
   legacy: false,
   fallbackLocale: "en",
   messages,
 })
-export const locale = i18n.global
-  .locale as unknown as WritableComputedRef<string>

--- a/resources/application/main.ts
+++ b/resources/application/main.ts
@@ -1,6 +1,6 @@
 import { initializeHybridly } from "hybridly/vue"
 import { createHead } from "@vueuse/head"
-import { i18n, locale } from "./i18n"
+import { i18n } from "./i18n"
 import "virtual:hybridly/router"
 import "./tailwind.css"
 import { definePlugin } from "hybridly"
@@ -9,14 +9,13 @@ initializeHybridly({
   cleanup: !import.meta.env.DEV,
   pages: import.meta.glob("@/views/pages/**/*.vue", { eager: true }),
   enhanceVue: (vue) => {
-    locale.value = useProperty("locale").value
     vue.use(createHead()).use(i18n)
   },
   plugins: [
     definePlugin({
-      name: "custom:define-locale",
-      after() {
-        locale.value = useProperty("locale").value
+      name: "custom:set-locale",
+      navigated() {
+        i18n.global.locale.value = useProperty("locale").value
       },
     }),
   ],

--- a/resources/views/components/locale-switcher.vue
+++ b/resources/views/components/locale-switcher.vue
@@ -8,17 +8,17 @@
     <template #dropdown>
       <div class="mt-2 text-sm bg-white rounded shadow-xl">
         <router-link
-          v-for="locale in availableLocales"
-          :key="locale"
+          v-for="availableLocale in availableLocales"
+          :key="availableLocale"
           as="button"
           method="POST"
           class="block py-2 px-6 w-full rounded-t hover:text-white hover:bg-indigo-500"
           :class="{
-            'text-white bg-indigo-500': currentLocale === locale,
+            'text-white bg-indigo-500': availableLocale === currentLocale,
           }"
-          :href="route('locale.set', { locale })"
+          :href="route('locale.set', { locale: availableLocale })"
         >
-          {{ t(`locales.${locale}`) }}
+          {{ t(`locales.${availableLocale}`) }}
         </router-link>
       </div>
     </template>
@@ -26,6 +26,5 @@
 </template>
 
 <script setup lang="ts">
-const { t, availableLocales } = useI18n()
-const currentLocale = useProperty("locale")
+const { t, availableLocales, locale: currentLocale } = useI18n()
 </script>


### PR DESCRIPTION
Previously, vue-i18n's locale was specified in two places:
* When initializing Hybridly and passing the i18n instance to Vue
* After a hybrid request has been made (using the `after` hook)

This PR makes it so we only have to specify the locale when a navigation has been made (using the `navigated` hook), making things a bit less redundant.